### PR TITLE
Update CI config to run checks using latest version of Elixir and OTP

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.13.2' # Define the elixir version [required]
+        elixir-version: '1.15.6' # Define the elixir version [required]
         otp-version: '24.X' # Define the OTP version [required]
     - name: Restore dependencies cache
       uses: actions/cache@v3


### PR DESCRIPTION
This PR brings the Elixir and Erlang/OTP versions specified in our CI configurations to their most recent releases