### PR TITLE
Telemetry/use configuration based strategy for batch telemetry

### DIFF
--- a/lib/config/config.ex
+++ b/lib/config/config.ex
@@ -1,0 +1,7 @@
+defmodule Pacer.Config do
+  @moduledoc """
+  The #{inspect(__MODULE__)} provides functions for
+  extracting user-provided configuration values specific
+  to Pacer.
+  """
+end

--- a/lib/config/config.ex
+++ b/lib/config/config.ex
@@ -4,4 +4,22 @@ defmodule Pacer.Config do
   extracting user-provided configuration values specific
   to Pacer.
   """
+
+  @spec batch_telemetry_options(module()) :: map()
+  def batch_telemetry_options(workflow_module) do
+    case :persistent_term.get({__MODULE__, workflow_module, :batch_telemetry_options}, :unset) do
+      :unset -> fetch_and_write({workflow_module, :batch_telemetry_options})
+      config -> config
+    end
+  end
+
+  @spec fetch_and_write({workflow_module, key}) :: map() when key: atom(), workflow_module: module()
+  defp fetch_and_write({workflow_module, key}) do
+    global_config = Application.get_env(:pacer, key) || %{}
+    module_config = workflow_module.__config__(key) || %{}
+
+    global_config
+    |> Map.merge(module_config)
+    |> tap(&:persistent_term.put({__MODULE__, workflow_module, key}, &1))
+  end
 end

--- a/lib/config/config.ex
+++ b/lib/config/config.ex
@@ -5,7 +5,7 @@ defmodule Pacer.Config do
   to Pacer.
   """
 
-  @spec batch_telemetry_options(module()) :: map()
+  @spec batch_telemetry_options(module()) :: keyword() | {module(), atom(), list()}
   def batch_telemetry_options(workflow_module) do
     case :persistent_term.get({__MODULE__, workflow_module, :batch_telemetry_options}, :unset) do
       :unset -> fetch_and_write({workflow_module, :batch_telemetry_options})
@@ -13,13 +13,35 @@ defmodule Pacer.Config do
     end
   end
 
-  @spec fetch_and_write({workflow_module, key}) :: map() when key: atom(), workflow_module: module()
-  defp fetch_and_write({workflow_module, key}) do
-    global_config = Application.get_env(:pacer, key) || %{}
-    module_config = workflow_module.__config__(key) || %{}
+  @spec fetch_batch_telemetry_options(module()) :: map()
+  def fetch_batch_telemetry_options(workflow_module) do
+    case batch_telemetry_options(workflow_module) do
+      {mod, fun, args} -> Map.new(apply(mod, fun, args))
+      opts -> Map.new(opts)
+    end
+  end
 
-    global_config
-    |> Map.merge(module_config)
-    |> tap(&:persistent_term.put({__MODULE__, workflow_module, key}, &1))
+  @spec fetch_and_write({workflow_module, :batch_telemetry_options}) ::
+          keyword() | {module(), atom(), list()}
+        when workflow_module: module()
+  defp fetch_and_write({workflow_module, :batch_telemetry_options = key}) do
+    global_config = Application.get_env(:pacer, key) || []
+    module_config = workflow_module.__config__(key) || []
+
+    cond do
+      is_list(global_config) && is_list(module_config) ->
+        global_config
+        |> Keyword.merge(module_config)
+        |> tap(&:persistent_term.put({__MODULE__, workflow_module, key}, &1))
+
+      match?({_m, _f, _a}, module_config) || is_list(module_config) ->
+        tap(module_config, &:persistent_term.put({__MODULE__, workflow_module, key}, &1))
+
+      match?({_m, _f, _a}, global_config) || is_list(global_config) ->
+        tap(global_config, &:persistent_term.put({__MODULE__, workflow_module, key}, &1))
+
+      true ->
+        tap([], &:persistent_term.put({__MODULE__, workflow_module, key}, &1))
+    end
   end
 end

--- a/lib/config/config.ex
+++ b/lib/config/config.ex
@@ -1,6 +1,6 @@
 defmodule Pacer.Config do
   @moduledoc """
-  The #{inspect(__MODULE__)} provides functions for
+  The #{inspect(__MODULE__)} module provides functions for
   extracting user-provided configuration values specific
   to Pacer.
   """

--- a/lib/config/config.ex
+++ b/lib/config/config.ex
@@ -5,6 +5,21 @@ defmodule Pacer.Config do
   to Pacer.
   """
 
+  @doc """
+  Fetches configuration options for extending the metadata provided in the
+  `[:pacer, :execute_vertex, :start | :stop | :exception]` events for batched resolvers.
+
+  The configuration must be set under the key `:batch_telemetry_options` at the application
+  level (i.e., `Application.get_env(:pacer, :batch_telemetry_options)`) or when defining the
+  workflow itself (`use Pacer.Workflow, batch_telemetry_options: <opts>`).
+
+  The batch_telemetry_options defined by the user must be either:
+    - a keyword list, or
+    - a {module, function, args} mfa tuple; when invoked, this function must return a keyword list
+
+  The keyword list of values returned by the mfa-style config, or the hardcoded keyword list, is
+  fetched and converted into a map that gets merged into the telemetry event metadata for batched resolvers.
+  """
   @spec batch_telemetry_options(module()) :: keyword() | {module(), atom(), list()}
   def batch_telemetry_options(workflow_module) do
     case :persistent_term.get({__MODULE__, workflow_module, :batch_telemetry_options}, :unset) do
@@ -13,6 +28,12 @@ defmodule Pacer.Config do
     end
   end
 
+  @doc """
+  Takes the batch_telemetry_options configuration, invoking mfa-style config if available,
+  and converts the batch_telemetry_options keyword list into a map that gets merged into
+  the metadata for the `[:pacer, :execute_vertex, :start | :stop | :exception]` events for
+  batched resolvers.
+  """
   @spec fetch_batch_telemetry_options(module()) :: map()
   def fetch_batch_telemetry_options(workflow_module) do
     case batch_telemetry_options(workflow_module) do

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -260,6 +260,91 @@ defmodule Pacer.Workflow do
 
   The order fields are defined in within a `graph` definition does not matter. For example, if you have a field `:request_one` that depends
   on another field `:request_two`, the fields can be declared in any order.
+
+  ## Telemetry
+
+  Pacer provides two levels of granularity for workflow telemetry: one at the entire workflow level, and one at the resolver level.
+
+  For workflow execution, Pacer will trigger the following telemetry events:
+
+  - `[:pacer, :workflow, :start]`
+      - Measurements include: `%{system_time: integer(), monotonic_time: integer()}`
+      - Metadata provided: `%{telemetry_span_context: term(), workflow: module()}`, where the `workflow` key contains the module name for the workflow being executed
+  - `[:pacer, :workflow, :stop]`
+     - Measurements include: `%{duration: integer(), monotonic_time: integer()}`
+     - Metadata provided: `%{telemetry_span_context: term(), workflow: module()}`, where the `workflow` key contains the module name for the workflow being executed
+  - `[:pacer, :workflow, :exception]`
+      - Measurements include: `%{duration: integer(), monotonic_time: integer()}`
+      - Metadata provided: %{kind: :throw | :error | :exit, reason: term(), stacktrace: list(), telemetry_span_context: term(), workflow: module()}, where the `workflow` key contains the module name for the workflow being executed
+
+  At the resolver level, Pacer will trigger the following telemetry events:
+
+  - `[:pacer, :execute_vertex, :start]`
+      - Measurements and metadata similar to `:workflow` start event, with the addition of the `%{field: atom()}` value passed in metadata. The `field` is the name of the field for which the resolver is being executed.
+  - `[:pacer, :execute_vertex, :stop]`
+      - Measurements and metadata similar to `:workflow` stop event, with the addition of the `%{field: atom()}` value passed in metadata. The `field` is the name of the field for which the resolver is being executed.
+  - `[:pacer, :execute_vertex, :exception]`
+      - Measurements and metadata similar to `:workflow` exception event, with the addition of the `%{field: atom()}` value passed in metadata. The `field` is the name of the field for which the resolver is being executed.
+
+  Additionally, for `[:pacer, :execute_vertex]` events fired on batched resolvers (which will run in parallel processes), users can provide their own metadata through configuration.
+
+  Users may provide either a keyword list of options which will be merged into the `:execute_vertex` event metadata, or an MFA `{mod, fun, args}` tuple that points to a function which
+  returns a keyword list that will be merged into the `:execute_vertex` event metadata.
+
+  There are two routes for configuring these telemetry options for batched resolvers: in the application environment using the `:pacer, :batch_telemetry_options` config key, or
+  on the individual workflow modules themselves by passing `:batch_telemetry_options` when invoking `use Pacer.Workflow`.
+  Configuration defined at the workflow module will override configuration defined in the application environment.
+
+  Here are a couple of examples:
+
+  ### User-Provided Telemetry Metadata for Batched Resolvers in Applicaton Config
+  ```elixir
+  # In config.exs (or whatever env config file you want to target):
+
+  config :pacer, :batch_telemetry_options, application_name: MyApp
+
+  ## When you invoke a workflow with batched resolvers now, you will get `%{application_name: MyApp}` merged into your
+  ## event metadata in the `[:pacer, :execute_vertex, :start | :stop | :exception]` events.
+  ```
+
+  ### User-Provided Telemetry Metadata for Batched Resolvers at the Workflow Level
+  ```elixir
+  defmodule MyWorkflow do
+    use Pacer.Workflow, batch_telemetry_options: [extra_context: "some context from my application"]
+
+    graph do
+      field(:a)
+
+      batch :long_running_requests do
+        field(:b, dependencies: [:a], resolver: &Requests.trigger_b/1, default: nil)
+        field(:c, dependencies: [:a], resolver: &Requests.trigger_c/1, default: nil)
+      end
+    end
+  end
+
+  ## Now when you invoke `Pacer.execute(MyWorkflow)`, you will get `%{extra_context: "some context from my application"}`
+  ## merged into the metadata for the `[:pacer, :execute_vertex, :start | :stop | :exception]` events for fields `:b` and `:c`
+  ```
+
+  Note that you can also provide an MFA tuple that points to a module/function that returns a keyword list of options to be
+  injected into the metadata on `:execute_vertex` telemetry events for batched resolvers. This allows users to execute code at runtime
+  to inject dynamic values into the metadata. Users may use this to inject things like span_context from the top-level workflow process
+  into the parallel processes that run the batch resolvers. This lets you propagate context from, i.e., a process dictionary at the top-level
+  into the sub-processes:
+
+  ```elixir
+  defmodule MyApp.BatchOptions do
+    def inject_context do
+      [span_context: MyTracingLibrary.Tracer.current_context()]
+    end
+  end
+
+  ## Use this function to inject span context by configuring it at the workflow level or in the application environment
+
+  ## In config.exs:
+
+  config :pacer, :batch_telemetry_options, {MyApp.BatchOptions, :inject_context, []}
+  ```
   """
   alias Pacer.Config
   alias Pacer.Workflow.Error

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -317,6 +317,10 @@ defmodule Pacer.Workflow do
         generate_docs?
       )
 
+      batch_telemetry_options = Keyword.get(unquote(opts), :batch_telemetry_options, %{})
+
+      Module.put_attribute(__MODULE__, :pacer_batch_telemetry_options, batch_telemetry_options)
+
       Module.register_attribute(__MODULE__, :pacer_docs, accumulate: true)
       Module.register_attribute(__MODULE__, :pacer_graph_vertices, accumulate: true)
       Module.register_attribute(__MODULE__, :pacer_field_to_batch_mapping, accumulate: false)
@@ -550,6 +554,9 @@ defmodule Pacer.Workflow do
           end)
 
         defstruct Enum.reverse(@pacer_struct_fields)
+
+        def __config__(:batch_telemetry_options), do: @pacer_batch_telemetry_options
+        def __config__(_), do: nil
 
         def __graph__(:fields), do: Enum.reverse(@pacer_fields)
         def __graph__(:dependencies), do: Enum.reverse(@pacer_dependencies)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Pacer.MixProject do
   use Mix.Project
 
   @name "Pacer"
-  @version "0.1.0"
+  @version "0.2.0"
   @source_url "https://github.com/carsdotcom/pacer"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Pacer.MixProject do
   use Mix.Project
 
   @name "Pacer"
-  @version "0.2.0"
+  @version "0.1.2"
   @source_url "https://github.com/carsdotcom/pacer"
 
   def project do

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -26,16 +26,16 @@ defmodule Pacer.ConfigTest do
     end
 
     test "returns an empty map if no user-provided options are available" do
-      assert Config.batch_telemetry_options(NoOptions) == %{}
+      assert Config.batch_telemetry_options(NoOptions) == []
     end
 
     test "returns global batch_telemetry_options if no module-level options are provided" do
-      Application.put_env(:pacer, :batch_telemetry_options, %{foo: "bar"})
-      assert Config.batch_telemetry_options(NoOptions) == %{foo: "bar"}
+      Application.put_env(:pacer, :batch_telemetry_options, foo: "bar")
+      assert Config.batch_telemetry_options(NoOptions) == [foo: "bar"]
     end
 
     defmodule TestBatchConfig do
-      use Pacer.Workflow, batch_telemetry_options: %{batched: "config"}
+      use Pacer.Workflow, batch_telemetry_options: [batched: "config"]
 
       graph do
         field(:foo)
@@ -43,15 +43,15 @@ defmodule Pacer.ConfigTest do
     end
 
     test "returns module-level options when provided" do
-      assert Config.batch_telemetry_options(TestBatchConfig) == %{batched: "config"}
+      assert Config.batch_telemetry_options(TestBatchConfig) == [batched: "config"]
     end
 
     test "module-level batch_telemetry_options overrides global batch_telemetry_options" do
-      Application.put_env(:pacer, :batch_telemetry_options, %{
+      Application.put_env(:pacer, :batch_telemetry_options,
         batched: "this value should be overridden"
-      })
+      )
 
-      assert Config.batch_telemetry_options(TestBatchConfig) == %{batched: "config"}
+      assert Config.batch_telemetry_options(TestBatchConfig) == [batched: "config"]
     end
   end
 end

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -30,5 +30,17 @@ defmodule Pacer.ConfigTest do
       Application.put_env(:pacer, :batch_telemetry_options, %{foo: "bar"})
       assert Config.batch_telemetry_options(NoOptions) == %{foo: "bar"}
     end
+
+    defmodule TestBatchConfig do
+      use Pacer.Workflow, batch_telemetry_options: %{batched: "config"}
+
+      graph do
+        field(:foo)
+      end
+    end
+
+    test "returns module-level options when provided" do
+      assert Config.batch_telemetry_options(TestBatchConfig) == %{batched: "config"}
+    end
   end
 end

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -79,4 +79,37 @@ defmodule Pacer.ConfigTest do
                {TestConfigWithMFA, :batch_telemetry_opts, []}
     end
   end
+
+  describe "fetch_batch_telemetry_options/1" do
+    defmodule MyWorkflowExample do
+      use Pacer.Workflow
+
+      graph do
+        field(:foo)
+      end
+
+      def default_options do
+        [
+          foo: "bar",
+          baz: "quux"
+        ]
+      end
+    end
+
+    test "invokes {module, fun, args} style config when present and converts the keyword list returned into a map" do
+      Application.put_env(
+        :pacer,
+        :batch_telemetry_options,
+        {MyWorkflowExample, :default_options, []}
+      )
+
+      assert Config.fetch_batch_telemetry_options(MyWorkflowExample) == %{foo: "bar", baz: "quux"}
+    end
+
+    test "converts keyword list style configuration into a map" do
+      Application.put_env(:pacer, :batch_telemetry_options, foo: "bar", baz: "quux")
+
+      assert Config.fetch_batch_telemetry_options(MyWorkflowExample) == %{foo: "bar", baz: "quux"}
+    end
+  end
 end

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -1,6 +1,7 @@
 defmodule Pacer.ConfigTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
+  alias Pacer.ConfigTest.NoOptions
   alias Pacer.Config
 
   describe "batch_telemetry_options/1" do
@@ -8,6 +9,8 @@ defmodule Pacer.ConfigTest do
       default = Application.get_env(:pacer, :batch_telemetry_options)
 
       on_exit(fn ->
+        :persistent_term.erase({Config, NoOptions, :batch_telemetry_options})
+        :persistent_term.erase({Config, TestBatchConfig, :batch_telemetry_options})
         Application.put_env(:pacer, :batch_telemetry_options, default)
       end)
 
@@ -40,6 +43,14 @@ defmodule Pacer.ConfigTest do
     end
 
     test "returns module-level options when provided" do
+      assert Config.batch_telemetry_options(TestBatchConfig) == %{batched: "config"}
+    end
+
+    test "module-level batch_telemetry_options overrides global batch_telemetry_options" do
+      Application.put_env(:pacer, :batch_telemetry_options, %{
+        batched: "this value should be overridden"
+      })
+
       assert Config.batch_telemetry_options(TestBatchConfig) == %{batched: "config"}
     end
   end

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -1,0 +1,19 @@
+defmodule Pacer.ConfigTest do
+  use ExUnit.Case
+
+  alias Pacer.Config
+
+  describe "batch_telemetry_options/1" do
+    defmodule NoOptions do
+      use Pacer.Workflow
+
+      graph do
+        field(:foo)
+      end
+    end
+
+    test "returns an empty map if no user-provided options are available" do
+      assert Config.batch_telemetry_options(NoOptions) == %{}
+    end
+  end
+end

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -71,5 +71,12 @@ defmodule Pacer.ConfigTest do
       assert Config.batch_telemetry_options(TestConfigWithMFA) ==
                {TestConfigWithMFA, :batch_telemetry_opts, []}
     end
+
+    test "module config overrides global config when both are present and use {module, function, args} style config" do
+      Application.put_env(:pacer, :batch_telemetry_options, {PacerGlobal, :default_options, []})
+
+      assert Config.batch_telemetry_options(TestConfigWithMFA) ==
+               {TestConfigWithMFA, :batch_telemetry_opts, []}
+    end
   end
 end

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -34,6 +34,11 @@ defmodule Pacer.ConfigTest do
       assert Config.batch_telemetry_options(NoOptions) == [foo: "bar"]
     end
 
+    test "accepts {module, function, args} tuples for batch_telemetry_options from global config" do
+      Application.put_env(:pacer, :batch_telemetry_options, {MyTelemetryOptions, :run, []})
+      assert Config.batch_telemetry_options(NoOptions) == {MyTelemetryOptions, :run, []}
+    end
+
     defmodule TestBatchConfig do
       use Pacer.Workflow, batch_telemetry_options: [batched: "config"]
 

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -4,19 +4,19 @@ defmodule Pacer.ConfigTest do
   alias Pacer.ConfigTest.NoOptions
   alias Pacer.Config
 
+  setup do
+    default = Application.get_env(:pacer, :batch_telemetry_options)
+
+    on_exit(fn ->
+      :persistent_term.erase({Config, NoOptions, :batch_telemetry_options})
+      :persistent_term.erase({Config, TestBatchConfig, :batch_telemetry_options})
+      Application.put_env(:pacer, :batch_telemetry_options, default)
+    end)
+
+    :ok
+  end
+
   describe "batch_telemetry_options/1" do
-    setup do
-      default = Application.get_env(:pacer, :batch_telemetry_options)
-
-      on_exit(fn ->
-        :persistent_term.erase({Config, NoOptions, :batch_telemetry_options})
-        :persistent_term.erase({Config, TestBatchConfig, :batch_telemetry_options})
-        Application.put_env(:pacer, :batch_telemetry_options, default)
-      end)
-
-      :ok
-    end
-
     defmodule NoOptions do
       use Pacer.Workflow
 

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -4,6 +4,16 @@ defmodule Pacer.ConfigTest do
   alias Pacer.Config
 
   describe "batch_telemetry_options/1" do
+    setup do
+      default = Application.get_env(:pacer, :batch_telemetry_options)
+
+      on_exit(fn ->
+        Application.put_env(:pacer, :batch_telemetry_options, default)
+      end)
+
+      :ok
+    end
+
     defmodule NoOptions do
       use Pacer.Workflow
 
@@ -14,6 +24,11 @@ defmodule Pacer.ConfigTest do
 
     test "returns an empty map if no user-provided options are available" do
       assert Config.batch_telemetry_options(NoOptions) == %{}
+    end
+
+    test "returns global batch_telemetry_options if no module-level options are provided" do
+      Application.put_env(:pacer, :batch_telemetry_options, %{foo: "bar"})
+      assert Config.batch_telemetry_options(NoOptions) == %{foo: "bar"}
     end
   end
 end

--- a/test/config/config_test.exs
+++ b/test/config/config_test.exs
@@ -58,5 +58,18 @@ defmodule Pacer.ConfigTest do
 
       assert Config.batch_telemetry_options(TestBatchConfig) == [batched: "config"]
     end
+
+    defmodule TestConfigWithMFA do
+      use Pacer.Workflow, batch_telemetry_options: {__MODULE__, :batch_telemetry_opts, []}
+
+      graph do
+        field(:foo)
+      end
+    end
+
+    test "returns {module, function, args} options stored in module config" do
+      assert Config.batch_telemetry_options(TestConfigWithMFA) ==
+               {TestConfigWithMFA, :batch_telemetry_opts, []}
+    end
   end
 end

--- a/test/workflow_test.exs
+++ b/test/workflow_test.exs
@@ -242,6 +242,22 @@ defmodule Pacer.WorkflowTest do
     end
   end
 
+  describe "workflow config" do
+    defmodule WorkflowWithBatchOptions do
+      use Pacer.Workflow, batch_telemetry_options: %{some_options: "foo"}
+
+      graph do
+        field(:bar)
+      end
+    end
+
+    test "allows batch_telemetry_config option to be passed" do
+      assert WorkflowWithBatchOptions.__config__(:batch_telemetry_options) == %{
+               some_options: "foo"
+             }
+    end
+  end
+
   describe "graph validations" do
     test "options validations" do
       module = """

--- a/test/workflow_test.exs
+++ b/test/workflow_test.exs
@@ -256,6 +256,18 @@ defmodule Pacer.WorkflowTest do
                some_options: "foo"
              }
     end
+
+    defmodule WorkflowWithNoConfigOptions do
+      use Pacer.Workflow
+
+      graph do
+        field(:foo)
+      end
+    end
+
+    test "returns nil for missing or non-existent config values" do
+      assert is_nil(WorkflowWithNoConfigOptions.__config__(:foo))
+    end
   end
 
   describe "graph validations" do


### PR DESCRIPTION
## What

This PR sets up an option for users to provide their own metadata that gets injected into Telemetry events for batched field resolvers. 

Users can now provide a `:batch_telemetry_options` config key under the `:pacer` application environment, or can provide `batch_telemetry_options` as a configuration option on a per-workflow basis. 

The `batch_telemetry_options` config value must be either a keyword list or an MFA tuple that indicates a function returning a keyword list. The keyword list will then be converted into a map and merged into the telemetry metadata for the `[:pacer, :execute_vertex, :start | :stop | :exception]` events when fired during batched field resolution.

## Why

Pacer uses `Task.async_stream/3` to run resolvers in a batch in parallel. Since Pacer is spinning up extra processes, there may be cases in which users want to propagate things like trace context stored in the overall workflow process' process dictionary into the processes where the batched resolvers are running. 

This configuration option also allows users to inject other arbitrary data into the event metadata for batched fields.

## Validation/Verification

You can validate this on a couple of different levels: one by providing options at the application level, and again at the workflow level. You can validate all of this in iex:

```elixir
global_config = [my_key: "some arbitrary data"]
Application.put_env(:pacer, :batch_telemetry_options, global_config)

defmodule TestWorkflow do
  use Pacer.Workflow

  graph do
    field(:a)
    batch :my_batch do
      field(:b, resolver: &__MODULE__.run/1, dependencies: [:a], default: nil)
      field(:c, resolver: &__MODULE__.run/1, dependencies: [:a], default: nil)
    end
  end
  
  def run(_), do: :ok 
end

defmodule Handler do
  def handle_event([:pacer, :execute_vertex, _], _, metadata, _) do
    IO.inspect(metadata, label: "metadata")
  end
end

prefix = [:pacer, :execute_vertex]
:ok = :telemetry.attach_many("test-event-handler", [prefix ++ [:start], prefix ++ [:stop], prefix ++ [:exception]], &Handler.handle_event/4, nil)

Pacer.Workflow.execute(TestWorkflow)

# => You should see IO.inspects of metadata, with the global config injected into the metadata for the batched fields

defmodule TelemetryContext do
  def inject do
    [my_context: "context #{:rand.uniform()}"]
  end
end

defmodule WorkflowLevelConfig do
  use Pacer.Workflow, batch_telemetry_options: {TelemetryContext, :inject, []}
  
  graph do
    field(:a)
    batch :my_batch do
      field(:b, resolver: &__MODULE__.run/1, dependencies: [:a], default: nil)
      field(:c, resolver: &__MODULE__.run/1, dependencies: [:a], default: nil)
    end
  end
  
  def run(_), do: :ok 
end

Pacer.Workflow.execute(WorkflowLevelConfig)

# => You should see IO.inspects of metadata, with the context injected by the `TelemetryContext.inject/0` merged into the metadata for the batched fields
```

## Additional Comments

It may make sense to allow users to inject their own metadata into _all_ pacer telemetry events if desired. That functionality was not addressed specifically in this PR. I will create an issue for a follow-up enhancement to this so that Pacer can enable users to inject metadata on all telemetry events fired within `Pacer.Workflow`.

 