### PR TITLE
Handle all kinds of errors in the workflow

### DIFF
--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -1018,8 +1018,8 @@ defmodule Pacer.Workflow do
           :telemetry.span([:pacer, :execute_vertex], metadata, fn ->
             {Map.put(workflow, field, resolver.(workflow)), metadata}
           end)
-        rescue
-          _error ->
+        catch
+          _kind, _error ->
             workflow
         end
 
@@ -1040,7 +1040,7 @@ defmodule Pacer.Workflow do
     |> Enum.map(fn {field, resolver} ->
       dependencies = module.__graph__(:batched_field_dependencies, field)
       # We want to also pass the current value (which is the default) of the field itself,
-      # so that we can use it in the rescue/fallback clause
+      # so that we can use it in the fallback clause
       partial_workflow = Map.take(workflow, [field | dependencies])
       {field, partial_workflow, resolver}
     end)
@@ -1063,8 +1063,8 @@ defmodule Pacer.Workflow do
                Map.merge(%{parent_pid: parent_pid}, user_provided_metadata)}
             end
           )
-        rescue
-          _error ->
+        catch
+          _kind, _error ->
             {field, Map.get(partial_workflow, field)}
         end
       end,


### PR DESCRIPTION
## What

Handles all kinds of errors in the workflow, including "stop loop" (throw, exit) errors from Erlang that could be sent from Finch lower in the stack.

## Why

[Finch](https://github.com/sneako/finch/blob/6b96517664bae8bff2783c248f8e858914a0bb96/lib/finch/http2/pool.ex#L55) errors not not being caught by the `rescue` block, [DD](https://app.datadoghq.com/apm/resource/postprocessingworkflow/Search.Lifecycle.PostProcessingWorkflow/e9ea0ee3205aae96?query=env%3Aproduction%20service%3Apostprocessingworkflow%20operation_name%3ASearch.Lifecycle.PostProcessingWorkflow&env=production&topGraphs=latency%3Alatency%2Chits%3Arate%2Cerrors%3Arate%2CbreakdownAs%3Aabsolute&traces=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&start=1698987600000&end=1699073940000&paused=true).

## Jira ticket

[CARS-13980](https://carscommerce.atlassian.net/browse/CARS-13980)

## Steps to Validate/Verify

1. In cars_platform `apps/engine/mix.exs` and `apps/cars_web/mix.exs` update the `:pacer` dep with `{:pacer, git: "https://github.com/codeadict/pacer/", branch: "handle_erlang_stop_loops"}`
1. Verify an ISA (the cat picture listing) [loads](http://localhost:4000/shopping/results/?stock_type=all&makes%5B%5D=&models%5B%5D=&zip=60606)
2. Verify the SRP behaves normally


[CARS-13980]: https://carscommerce.atlassian.net/browse/CARS-13980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ