### PR TITLE
Compile-Time Resolver Validations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ pacer-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+/.tool-versions

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -911,8 +911,12 @@ defmodule Pacer.Workflow do
   end
 
   defp validate_resolvers(module) do
-    for {field, resolver_fun} <- Module.get_attribute(module, :pacer_resolvers) do
-      Enum.into(Function.info(resolver_fun), %{})
+    module
+    |> Module.get_attribute(:pacer_resolvers)
+    |> Enum.map(fn {field, resolver_fun} ->
+      resolver_fun
+      |> Function.info()
+      |> Map.new()
       |> then(fn info ->
         unless function_exported?(info.module, info.name, info.arity) do
           raise Error, """
@@ -923,7 +927,7 @@ defmodule Pacer.Workflow do
           """
         end
       end)
-    end
+    end)
   end
 
   @spec ensure_no_duplicate_fields(module(), atom()) :: :ok | no_return()

--- a/test/workflow_test.exs
+++ b/test/workflow_test.exs
@@ -595,6 +595,30 @@ defmodule Pacer.WorkflowTest do
         Code.eval_string(module)
       end
     end
+
+    test "alerts users when a resolver function does not exist" do
+      module = """
+      defmodule GraphWithInvalidResolver do
+        use Pacer.Workflow
+
+        graph do
+          field(:a, resolver: &NonExistentModule.mispelled_function/1, dependencies: [:b])
+          field(:b, default: "foo")
+        end
+      end
+      """
+
+      expected_error_message = """
+      Resolver for field `:a` is undefined. Ensure that the resolver you intend to use
+      has been defined and you have no mispellings.
+
+      Resolver Function: &NonExistentModule.mispelled_function/1
+      """
+
+      assert_raise Error, expected_error_message, fn ->
+        Code.eval_string(module)
+      end
+    end
   end
 
   describe "batch validations" do


### PR DESCRIPTION
This PR adds an extra compile-time check on ensuring that resolver function references passed by users actually point to valid, existing functions.

Passing an undefined function to a resolver will now fail at compile time and provide users with feedback that notifies them of the error and how to fix it.

## Validations:

- A regression test is provided here https://github.com/carsdotcom/pacer/commit/b560b4c7d47b51062ba052428f11a93120700cd5. Check out this commit to see the test fail, then check out the latest from this branch and re-run the same test.

- Test this against some of your own Workflows


## Additional Notes

This is a step in the right direction, but incomplete. There are a class of problems that would lead to `FunctionClauseError`,  etc., that we cannot definitively catch at compile time. A good example of this would be if users provide a valid MFA reference for a resolver, but the definition of the function has specific pattern-matches that are incompatible with or not comprehensive enough to match the dependencies defined by a field in a `Pacer.Workflow`.

As a result, one idea we have is to allow for a `debug` mode option that can be opted into for `Pacer.Workflows` (and maybe set as a default in dev environments). In `debug` mode, we would log out any exceptions caught so that Pacer does not just silently swallow those types of errors. Behavior-wise, Pacer will still maintain the same behavior, but it will be more explicit for users when errors do happen at runtime.