### PR TITLE
Add debug mode

### DIFF
--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -345,6 +345,32 @@ defmodule Pacer.Workflow do
 
   config :pacer, :batch_telemetry_options, {MyApp.BatchOptions, :inject_context, []}
   ```
+
+  ### Using debug_mode config:
+
+  An optional config for debug mode will log out caught errors from batch resolvers.
+  This is helpful for local development as the workflow will catch the error and return
+  the default to keep the workflow continuing.
+
+  ```elixir
+  defmodule MyWorkflow do
+    use Pacer.Workfow, debug_mode?: true
+
+     graph do
+        field(:a, default: 1)
+
+        batch :http_requests do
+          field(:b, resolver: &__MODULE__.calculate_b/1, dependencies: [:a], default: :hello)
+        end
+      end
+
+      def calculate_b(%{a: _a}), do: raise("OH NO")
+  end
+  ```
+  When running the workflow above, field b will silently raise as the default
+  will be returned. In debug mode, you will also get a log telling you the error
+  and the default returned.
+
   """
   alias Pacer.Config
   alias Pacer.Workflow.Error

--- a/lib/workflow.ex
+++ b/lib/workflow.ex
@@ -911,29 +911,8 @@ defmodule Pacer.Workflow do
   @spec __after_compile__(Macro.Env.t(), binary()) :: :ok | no_return()
   def __after_compile__(%{module: module} = _env, _) do
     _ = validate_dependencies(module)
-    _ = validate_resolvers(module)
 
     :ok
-  end
-
-  defp validate_resolvers(module) do
-    module
-    |> Module.get_attribute(:pacer_resolvers)
-    |> Enum.map(fn {field, resolver_fun} ->
-      resolver_fun
-      |> Function.info()
-      |> Map.new()
-      |> then(fn info ->
-        unless function_exported?(info.module, info.name, info.arity) do
-          raise Error, """
-          Resolver for field `#{inspect(field)}` is undefined. Ensure that the resolver you intend to use
-          has been defined and you have no mispellings.
-
-          Resolver Function: #{inspect(resolver_fun)}
-          """
-        end
-      end)
-    end)
   end
 
   @spec ensure_no_duplicate_fields(module(), atom()) :: :ok | no_return()

--- a/test/workflow_test.exs
+++ b/test/workflow_test.exs
@@ -597,30 +597,6 @@ defmodule Pacer.WorkflowTest do
         Code.eval_string(module)
       end
     end
-
-    test "alerts users when a resolver function does not exist" do
-      module = """
-      defmodule GraphWithInvalidResolver do
-        use Pacer.Workflow
-
-        graph do
-          field(:a, resolver: &NonExistentModule.mispelled_function/1, dependencies: [:b])
-          field(:b, default: "foo")
-        end
-      end
-      """
-
-      expected_error_message = """
-      Resolver for field `:a` is undefined. Ensure that the resolver you intend to use
-      has been defined and you have no mispellings.
-
-      Resolver Function: &NonExistentModule.mispelled_function/1
-      """
-
-      assert_raise Error, expected_error_message, fn ->
-        Code.eval_string(module)
-      end
-    end
   end
 
   describe "batch validations" do


### PR DESCRIPTION
An optional debug mode can be passed in the definition of the workflow to log out errors that get caught in batch resolvers. 